### PR TITLE
Conform to pep8 import standards

### DIFF
--- a/Inkxbot.py
+++ b/Inkxbot.py
@@ -1,16 +1,15 @@
+from collections import Counter
+import traceback
+import datetime
+import logging
+import asyncio
+import copy
+import json
+import sys
+import os
+
 from discord.ext import commands
 import discord
-import datetime
-import re
-import json, asyncio
-import aiohttp
-import copy
-import logging
-import traceback
-import sys
-import subprocess
-from cogs.utils import checks
-from collections import Counter
 
 
 description = 'My command list is right here, each is used with a comma' # or a period' (in the future)

--- a/Inkxbotcogs/BackgroundtaskCog.py
+++ b/Inkxbotcogs/BackgroundtaskCog.py
@@ -1,5 +1,5 @@
-from discord.ext import commands
 import asyncio
+
 import discord
 
 

--- a/Inkxbotcogs/ChallongeCog.py
+++ b/Inkxbotcogs/ChallongeCog.py
@@ -1,11 +1,11 @@
-
-from selenium import webdriver
-from discord.ext import commands
-from .utils import checks
 import asyncio
-import discord
-import challonge
 import json
+
+from discord.ext import commands
+from selenium import webdriver
+import challonge
+import discord
+
 
 def load_challonge_urls():
     with open('challongeurls.json') as c:

--- a/Inkxbotcogs/DestinyCog.py
+++ b/Inkxbotcogs/DestinyCog.py
@@ -1,9 +1,8 @@
-from discord.ext import commands
-from .utils import config, checks#, hcards
-import asyncio, aiohttp
 from urllib.parse import quote as urlquote
-from collections import namedtuple
-import requests
+
+from discord.ext import commands
+import aiohttp
+
 
 class Destiny:
     def __init__(self, bot):

--- a/Inkxbotcogs/EasterEggs.py
+++ b/Inkxbotcogs/EasterEggs.py
@@ -1,8 +1,10 @@
-from discord.ext import commands
 import asyncio
-import discord
 import random
 import os
+
+from discord.ext import commands
+import discord
+
 
 class Easter_Eggs:
     """these commands are just for fun, they all might be removed someday"""

--- a/Inkxbotcogs/HearthstoneCog.py
+++ b/Inkxbotcogs/HearthstoneCog.py
@@ -1,9 +1,6 @@
 from discord.ext import commands
-from .utils import config, checks#, hcards
-import asyncio, aiohttp
+import aiohttp
 from urllib.parse import quote as urlquote
-from collections import namedtuple
-import requests
 
 class Hearthstone:
     def __init__(self, bot):

--- a/Inkxbotcogs/JustdanceCog.py
+++ b/Inkxbotcogs/JustdanceCog.py
@@ -1,9 +1,9 @@
-from discord.ext import commands
-from .utils import config, checks
-import asyncio, aiohttp
 from urllib.parse import quote as urlquote
-from collections import namedtuple
-import requests
+import asyncio
+
+from discord.ext import commands
+import aiohttp
+
 
 class Just_Dance:
     def __init__(self, bot):

--- a/Inkxbotcogs/MetaCog.py
+++ b/Inkxbotcogs/MetaCog.py
@@ -1,12 +1,6 @@
-from discord.ext import commands
-from .utils import checks, formats
-import discord
-from collections import OrderedDict, deque, Counter
-import os, datetime
-import re, asyncio
-import copy
 import unicodedata
-import inspect
+
+from discord.ext import commands
 
 
 class Meta:

--- a/Inkxbotcogs/MiscCog.py
+++ b/Inkxbotcogs/MiscCog.py
@@ -1,7 +1,9 @@
-from selenium import webdriver
-from discord.ext import commands
 import asyncio
+
+from discord.ext import commands
+from selenium import webdriver
 import discord
+
 
 class Misc:
     """ Miscellaneous commands. """

--- a/Inkxbotcogs/ScoresForBattles.py
+++ b/Inkxbotcogs/ScoresForBattles.py
@@ -1,19 +1,22 @@
-from discord.ext import commands
-from .utils import checks
-import discord
 import asyncio
-import json
 import logging
+import json
+
+from discord.ext import commands
+import discord
 
 log = logging.getLogger()
+
 
 def load_teams():
     with open('teams.json') as l:
         return json.load(l)
 
+
 def load_trnynames():
     with open('tournamentnames.json') as t:
         return json.load(t)
+
 
 class Scoring:
     """Commands that display scores from e-sport battles against teams."""

--- a/Inkxbotcogs/SplatoonCog.py
+++ b/Inkxbotcogs/SplatoonCog.py
@@ -1,20 +1,17 @@
-from discord.ext import commands
-
-import datetime
-import random
-import urllib
 import asyncio
-import discord
 import logging
-import aiohttp
-import yarl
+import urllib
 import json
-import re
 
+from discord.ext import commands
+import discord
+
+log = logging.getLogger()
 
 def load_schedule():
     with urllib.request.urlopen("https://splatoon.ink/schedule2.json") as url:
         return json.loads(url.read().decode())
+
 
 def mode_key(argument):
     lower = argument.lower().strip('"')
@@ -26,6 +23,7 @@ def mode_key(argument):
         return 'League Battle'
     else:
         raise commands.BadArgument('Unknown schedule type, try: "ranked", "regular", or "league"')
+
 
 class Splatoon:
     """Splatoon 2 related commands."""

--- a/Inkxbotcogs/StatsCog.py
+++ b/Inkxbotcogs/StatsCog.py
@@ -1,14 +1,11 @@
-from discord.ext import commands
 from collections import Counter
-
-from .utils import checks
-
+import datetime
 import asyncio
 import logging
+
+from discord.ext import commands
 import discord
-import datetime
 import psutil
-import os
 
 log = logging.getLogger()
 

--- a/Inkxbotcogs/admin.py
+++ b/Inkxbotcogs/admin.py
@@ -1,15 +1,16 @@
-from discord.ext import commands
-import asyncio
-import traceback
-import discord
-import inspect
-import textwrap
 from contextlib import redirect_stdout
+import traceback
+import textwrap
+import asyncio
 import io
+
+from discord.ext import commands
+import discord
 
 # to expose to the eval command
 import datetime
 from collections import Counter
+
 
 class Admin:
     """Admin-only commands that make the bot dynamic."""

--- a/Inkxbotcogs/dbots.py
+++ b/Inkxbotcogs/dbots.py
@@ -1,8 +1,7 @@
-import aiohttp
-import json
 import logging
-import discord
+import json
 
+import aiohttp
 
 log = logging.getLogger()
 

--- a/Inkxbotcogs/modcog.py
+++ b/Inkxbotcogs/modcog.py
@@ -1,11 +1,14 @@
-from discord.ext import commands
-from .utils import config, checks
 import asyncio
+import json
+
+from discord.ext import commands
 import discord
+
 
 def load_messages():
     with open('servermessage.json') as m:
         return json.load(m)
+
 
 class Moderation:
     """ Moderative Commands to keep the server clean """
@@ -13,15 +16,12 @@ class Moderation:
     def __init__(self, bot):
         self.bot = bot
 
-
-
     def _role_from_string(self, server, rolename, roles=None):
         if roles is None:
             roles = server.roles
         role = discord.utils.find(lambda r: r.name.lower() == rolename.lower(),roles)
 
         return role
-
 
     @commands.command(name = 'clear', invoke_without_command=True)
     @commands.guild_only()
@@ -78,7 +78,7 @@ class Moderation:
         if user is None:
             user = ctx.message.author
 
-        role = self._role_from_string(server, rolename)
+        role = self._role_from_string(ctx.guild, rolename)
 
         if role is None:
             await ctx.trigger_typing()
@@ -86,7 +86,7 @@ class Moderation:
             await ctx.send('That role cannot be found.')
             return
 
-        if not channel.permissions_for(server.me).manage_roles:
+        if not ctx.channel.permissions_for(ctx.guild.me).manage_roles:
             await ctx.trigger_typing()
             await asyncio.sleep(1)
             await ctx.send("I don't have permissions to manage roles!")
@@ -104,7 +104,7 @@ class Moderation:
         """Removes a role from user, defaults to author
         Role name must be in quotes if there are spaces.
         You must have permissions to manage roles in order to use this"""
-        role = self._role_from_string(server, rolename)
+        role = self._role_from_string(ctx.guild, rolename)
         if role is None:
             await ctx.trigger_typing()
             await asyncio.sleep(1)
@@ -112,7 +112,7 @@ class Moderation:
             return
 
         if user is None:
-            user = author
+            user = ctx.author
 
         if role in user.roles:
             try:

--- a/Inkxbotcogs/utils/config.py
+++ b/Inkxbotcogs/utils/config.py
@@ -1,7 +1,8 @@
-import json
-import os
-import uuid
 import asyncio
+import json
+import uuid
+import os
+
 
 class Config:
     """The "database" object. Internally based on ``json``."""

--- a/Inkxbotcogs/utils/maps.py
+++ b/Inkxbotcogs/utils/maps.py
@@ -2,14 +2,17 @@
 
 # With credit to DanielKO and Danny
 
+import datetime
+import re
+
 from lxml import etree
-import datetime, re
-import asyncio, aiohttp
+import aiohttp
 
 NINTENDO_LOGIN_PAGE = "https://id.nintendo.net/oauth/authorize"
 SPLATNET_CALLBACK_URL = "https://splatoon.nintendo.net/users/auth/nintendo/callback"
 SPLATNET_CLIENT_ID = "12af3d0a3a1f441eb900411bb50a835a"
 SPLATNET_SCHEDULE_URL = "https://splatoon.nintendo.net/schedule"
+
 
 class Rotation(object):
     def __init__(self):


### PR DESCRIPTION
pep8 says that imports should be like so:

```
standard library

pypi packages

local imports
```

This PR also fixes a slight issue with undefined variables, as well as removing some unused imports.